### PR TITLE
2.7.1.6 式中の記号の間違いを修正

### DIFF
--- a/EngineeringReference_chapter02.adoc
+++ b/EngineeringReference_chapter02.adoc
@@ -1839,11 +1839,11 @@ E_{AC,ahu,h,i} = \sum_{d=1}^{365} \{ \max⁡(-C_{i,d},0) + \max⁡(-H_{i,d},0) \
 ++++++++++++++++++++++++++++++++++++++++++++
 [stem]
 ++++++++++++++++++++++++++++++++++++++++++++
-C_{i,d} = E_{AC,ahu,A,i,d} \times T_{AC,ahu,c,i,d} \times \frac{L_{AC,ahu,A,i,d}}{|L_{AC,ahu,A,i,d}|}
+C_{i,d} = E_{AC,ahu,C,i,d} \times T_{AC,ahu,c,i,d} \times \frac{L_{AC,ahu,C,i,d}}{|L_{AC,ahu,C,i,d}|}
 ++++++++++++++++++++++++++++++++++++++++++++
 [stem]
 ++++++++++++++++++++++++++++++++++++++++++++
-H_{i,d} = E_{AC,ahu,B,i,d} \times T_{AC,ahu,h,i,d}  \times \frac{L_{AC,ahu,B,i,d}}{|L_{AC,ahu,B,i,d}|}
+H_{i,d} = E_{AC,ahu,H,i,d} \times T_{AC,ahu,h,i,d}  \times \frac{L_{AC,ahu,H,i,d}}{|L_{AC,ahu,H,i,d}|}
 ++++++++++++++++++++++++++++++++++++++++++++
 ====
 

--- a/index.html
+++ b/index.html
@@ -5039,12 +5039,12 @@ E_{AC,ahu,h,i} = \sum_{d=1}^{365} \{ \max⁡(-C_{i,d},0) + \max⁡(-H_{i,d},0) \
 </div>
 <div class="stemblock">
 <div class="content">
-\[C_{i,d} = E_{AC,ahu,A,i,d} \times T_{AC,ahu,c,i,d} \times \frac{L_{AC,ahu,A,i,d}}{|L_{AC,ahu,A,i,d}|}\]
+\[C_{i,d} = E_{AC,ahu,C,i,d} \times T_{AC,ahu,c,i,d} \times \frac{L_{AC,ahu,C,i,d}}{|L_{AC,ahu,C,i,d}|}\]
 </div>
 </div>
 <div class="stemblock">
 <div class="content">
-\[H_{i,d} = E_{AC,ahu,B,i,d} \times T_{AC,ahu,h,i,d}  \times \frac{L_{AC,ahu,B,i,d}}{|L_{AC,ahu,B,i,d}|}\]
+\[H_{i,d} = E_{AC,ahu,H,i,d} \times T_{AC,ahu,h,i,d}  \times \frac{L_{AC,ahu,H,i,d}}{|L_{AC,ahu,H,i,d}|}\]
 </div>
 </div>
 </div>


### PR DESCRIPTION
冷房を表す記号を A -> C、暖房を表す記号を B -> Hに修正しました。