### PR TITLE
修正の提案

### DIFF
--- a/EngineeringReference_chapter02.adoc
+++ b/EngineeringReference_chapter02.adoc
@@ -2935,19 +2935,19 @@ stem:[min_{i,j},max_{i,j}]| 	熱源群iに属する熱源機器jの部分負荷�
 [stem]
 ++++++++++++++++++++++++++++++++++++++++++++
 F_{AC,ref,x,i,j,d}= \begin{cases}
-F   　　　,xL_{AC,ref,i,d} ≦ 1 \\
-F×1.2    ,xL_{AC,ref,i,d} > 1  \\
+F_{i,j}, & (OV_{AC,ref,i,d}=false) \\
+F_{i,j} \times 1.2, & (OV_{AC,ref,i,d}=true) \\
 \end{cases}
 ++++++++++++++++++++++++++++++++++++++++++++
 [stem]
 ++++++++++++++++++++++++++++++++++++++++++++
-F = a_{i,j} × L^4 + b_{i,j} × L^3 + c_{i,j} × L^2 + d_{i,j}×L + e_{i,j}
+F_{i,j} = a_{i,j} \times L_{i,j}^4 + b_{i,j} \times L_{i,j}^3 + c_{i,j} \times L_{i,j}^2 + d_{i,j} \times L_{i,j} + e_{i,j}
 ++++++++++++++++++++++++++++++++++++++++++++
 [stem]
 ++++++++++++++++++++++++++++++++++++++++++++
-L = \begin{cases}
- max⁡( min⁡(xL_{AC,ref,i,d},max_{i,j} ),min_{i,j} )  , xL_{AC,ref,i,d} ≦ 1 \\
- max_{i,j,d}                                       , xL_{AC,ref,i,d} > 1 \\
+L_{i,j} = \begin{cases}
+ max⁡( min⁡(xL_{AC,ref,i,d},max_{i,j} ),min_{i,j} ), & (OV_{AC,ref,i,d}=false) \\
+ max_{i,j,d}, & (OV_{AC,ref,i,d}=true) \\
 \end{cases}
 ++++++++++++++++++++++++++++++++++++++++++++
 ====


### PR DESCRIPTION
修正箇所は以下になります。

１）条件式の条件値を　&　と（）に揃える

２）計算過程の係数　F　と　L　は　i,j　に依存する値であり、添え字が無いと熱源機器で共通と誤認する可能性があるため、添え字を追加

３）条件の判定に「xL_AC,ref,i,d」が用いられているが、入力パラメータに過負荷判定「OV_AC,ref,i,d」を持ってきているため、OVに修正。
OVの判定は熱源の負荷Lのため、xLの判定とは結果が異なるので、xLが正しいかもしれない。

xL判定が正しい場合には、計算過程のLはxLとすべきと思われる。